### PR TITLE
Content State Update API - Refactoring - For Authorization and Mobile support

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/keys/SunbirdKey.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/keys/SunbirdKey.java
@@ -29,6 +29,10 @@ public final class SunbirdKey {
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String LAST_PUBLISHED_ON = "lastPublishedOn";
     public static final String REQUESTED_FOR = "requestedFor";
+    // Content Status Update API Specific - START
+    public static final String ACTUAL_USER_ID = "actualUserId";
+    public static final String ALL_USER_IDS = "allUserIds";
+    // Content Status Update API Specific - END
 
     private SunbirdKey() {}
 }

--- a/course-mw/course-actors/src/main/java/org/sunbird/learner/actors/LearnerStateUpdateActor.java
+++ b/course-mw/course-actors/src/main/java/org/sunbird/learner/actors/LearnerStateUpdateActor.java
@@ -30,7 +30,6 @@ import org.sunbird.learner.constants.InstructionEvent;
 import org.sunbird.learner.util.JsonUtil;
 import org.sunbird.learner.util.Util;
 import scala.concurrent.Future;
-import sun.util.logging.PlatformLogger;
 
 /**
  * This actor to handle learner's state update operation .

--- a/service/app/util/RequestValidator.java
+++ b/service/app/util/RequestValidator.java
@@ -44,7 +44,6 @@ public final class RequestValidator {
    */
   @SuppressWarnings("unchecked")
   public static void validateUpdateContent(Request contentRequestDto) {
-    setUserIdToRequest(contentRequestDto);
     List<Map<String, Object>> list =
             (List<Map<String, Object>>) (contentRequestDto.getRequest().get(JsonKey.CONTENTS));
     if(CollectionUtils.isNotEmpty(list)) {
@@ -160,36 +159,6 @@ public final class RequestValidator {
           }
         }
       }
-  }
-
-  private static void setUserIdToRequest(Request contentRequestDto) {
-    if (!contentRequestDto.getRequest().containsKey(JsonKey.USER_ID)
-            || StringUtils.isBlank((String) contentRequestDto.get(JsonKey.USER_ID))) {
-      List<Map<String, Object>> contentList =
-              (List<Map<String, Object>>) (contentRequestDto.getRequest().get(JsonKey.CONTENTS));
-      List<Map<String, Object>> assessmentList =
-              (List<Map<String, Object>>) (contentRequestDto.getRequest().get(JsonKey.ASSESSMENT_EVENTS));
-      List<String> userList = null;
-      if(CollectionUtils.isNotEmpty(contentList)) {
-        userList = contentList.stream().map(content -> (String) content.getOrDefault(JsonKey.USER_ID, ""))
-                .filter(value ->  StringUtils.isNotBlank(value)).distinct().collect(Collectors.toList());
-        
-      } else if(CollectionUtils.isNotEmpty(assessmentList)) {
-        userList = assessmentList.stream().map(content -> (String) content.getOrDefault(JsonKey.USER_ID, ""))
-                .filter(value ->  StringUtils.isNotBlank(value)).distinct().collect(Collectors.toList());
-      }
-      
-      if(CollectionUtils.isEmpty(userList) || StringUtils.isBlank(userList.get(0))) {
-        throw new ProjectCommonException(
-                ResponseCode.userIdRequired.getErrorCode(),
-                ResponseCode.userIdRequired.getErrorMessage(),
-                ERROR_CODE);
-      } else {
-        contentRequestDto.put(SunbirdKey.ACTUAL_USER_ID, contentRequestDto.get(JsonKey.USER_ID));
-        contentRequestDto.put(JsonKey.USER_ID, userList.get(0));
-        contentRequestDto.put(SunbirdKey.ALL_USER_IDS, userList.stream().collect(Collectors.joining(", ")));
-      }
-    }
   }
 
   /**

--- a/service/app/util/RequestValidator.java
+++ b/service/app/util/RequestValidator.java
@@ -14,6 +14,7 @@ import org.sunbird.common.models.util.StringFormatter;
 import org.sunbird.common.request.Request;
 import org.sunbird.common.responsecode.ResponseCode;
 import org.sunbird.common.responsecode.ResponseMessage;
+import org.sunbird.keys.SunbirdKey;
 
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
@@ -184,9 +185,9 @@ public final class RequestValidator {
                 ResponseCode.userIdRequired.getErrorMessage(),
                 ERROR_CODE);
       } else {
-        contentRequestDto.put("ACTUAL_USER_ID", contentRequestDto.get(JsonKey.USER_ID));
+        contentRequestDto.put(SunbirdKey.ACTUAL_USER_ID, contentRequestDto.get(JsonKey.USER_ID));
         contentRequestDto.put(JsonKey.USER_ID, userList.get(0));
-        contentRequestDto.put("ALL_USER_IDS", userList.stream().collect(Collectors.joining(", ")));
+        contentRequestDto.put(SunbirdKey.ALL_USER_IDS, userList.stream().collect(Collectors.joining(", ")));
       }
     }
   }


### PR DESCRIPTION
Identify users from auth tokens.
Use the authorized user-ids for updating the contents and assessments data.
If data doesn't contain userId,
- user the childId if exists, otherwise - use parentId.