### PR TITLE
Remove headers logging

### DIFF
--- a/service/app/modules/ErrorHandler.java
+++ b/service/app/modules/ErrorHandler.java
@@ -34,12 +34,7 @@ public class ErrorHandler extends DefaultHttpErrorHandler {
 
   @Override
   public CompletionStage<Result> onServerError(Http.RequestHeader request, Throwable t) {
-    ProjectLogger.log(
-        "Global: onError called for path = "
-            + request.path()
-            + ", headers = "
-            + request.getHeaders().toMap(),
-        t);
+    ProjectLogger.log("Global: onError called for path = " + request.path(), t);
     Response response = null;
     ProjectCommonException commonException = null;
     if (t instanceof ProjectCommonException) {


### PR DESCRIPTION
This is to handle the logging properly. We shouldn't log headers.