### PR TITLE
Including courseId, batchId and lastUpdatedOn fields in the response

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
@@ -52,7 +52,9 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
       response.put("metrics", result.get("metrics"))
       response.put("collectionId", collectionId)
       response.put("batchId", batchId)
-      response.put("lastUpdatedOn", new BigDecimal(result.get("lastUpdatedOn").toString).toBigInteger()) // Converting scientific notation number bigInteger(Long)
+      if(result.get("lastUpdatedOn") != null){
+        response.put("lastUpdatedOn", new BigDecimal(result.get("lastUpdatedOn").toString).toBigInteger()) // Converting scientific notation number bigInteger(Long)
+      }
       if (groupByKeys.nonEmpty) {
         response.put("groupBy", result.get("groupBy"))
       }

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
@@ -49,6 +49,9 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
         transformedResult
       }
       response.put("metrics", result.get("metrics"))
+      response.put("collectionId", collectionId)
+      response.put("batchId", batchId)
+      response.put("lastUpdatedOn", result.get("lastUpdatedOn"))
       if (groupByKeys.nonEmpty) {
         response.put("groupBy", result.get("groupBy"))
       }
@@ -91,6 +94,7 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
         Map("type" -> value._1, "count" -> value._2).asJava
       }).asJava
       transformedResult.put("metrics", metrics)
+      transformedResult.put("lastUpdatedOn", DateTime.now(DateTimeZone.UTC).getMillis().asInstanceOf[AnyRef])
       if (groupByKeys.nonEmpty) {
         transformedResult.put("groupBy", groupingResult)
       }

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
@@ -52,8 +52,10 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
       response.put("metrics", result.get("metrics"))
       response.put("collectionId", collectionId)
       response.put("batchId", batchId)
-      if(result.get("lastUpdatedOn") != null){
+      if (result.get("lastUpdatedOn") != null) {
         response.put("lastUpdatedOn", new BigDecimal(result.get("lastUpdatedOn").toString).toBigInteger()) // Converting scientific notation number bigInteger(Long)
+      } else {
+        response.put("lastUpdatedOn", DateTime.now(DateTimeZone.UTC).getMillis().asInstanceOf[AnyRef]) // This scenarios won't occurre, for the safer side adding this condition
       }
       if (groupByKeys.nonEmpty) {
         response.put("groupBy", result.get("groupBy"))

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
@@ -42,11 +42,11 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
     try {
       val redisData = cacheUtil.get(key)
       val result: util.Map[String, AnyRef] = if (null != redisData && !redisData.isEmpty) {
-        gson.fromJson(redisData, classOf[util.Map[String, AnyRef]])
+        JsonUtil.deserialize(redisData, new util.HashMap[String, AnyRef]().getClass)
       } else {
         val druidResponse = getResponseFromDruid(batchId = batchId, courseId = collectionId, granularity, groupByKeys = groupByKeys)
         val transformedResult = transform(druidResponse, groupByKeys)
-        if (!transformedResult.isEmpty) cacheUtil.set(key, gson.toJson(transformedResult), ttl)
+        if (!transformedResult.isEmpty) cacheUtil.set(key, JsonUtil.serialize(transformedResult), ttl)
         transformedResult
       }
       response.put("metrics", result.get("metrics"))

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/aggregate/CollectionSummaryAggregate.scala
@@ -18,6 +18,7 @@ import org.sunbird.common.request.{Request, RequestContext}
 import org.sunbird.learner.actors.coursebatch.dao.CourseBatchDao
 import org.sunbird.learner.actors.coursebatch.dao.impl.CourseBatchDaoImpl
 import org.sunbird.learner.util.{JsonUtil, Util}
+import java.math.BigDecimal
 
 import scala.collection.JavaConverters._
 
@@ -51,7 +52,7 @@ class CollectionSummaryAggregate @Inject()(implicit val cacheUtil: RedisCacheUti
       response.put("metrics", result.get("metrics"))
       response.put("collectionId", collectionId)
       response.put("batchId", batchId)
-      response.put("lastUpdatedOn", result.get("lastUpdatedOn"))
+      response.put("lastUpdatedOn", new BigDecimal(result.get("lastUpdatedOn").toString).toBigInteger()) // Converting scientific notation number bigInteger(Long)
       if (groupByKeys.nonEmpty) {
         response.put("groupBy", result.get("groupBy"))
       }

--- a/course-mw/enrolment-actor/src/test/scala/org/sunbird/aggregate/CollectionSummaryAggregateTest.scala
+++ b/course-mw/enrolment-actor/src/test/scala/org/sunbird/aggregate/CollectionSummaryAggregateTest.scala
@@ -131,6 +131,10 @@ class CollectionSummaryAggregateTest extends FlatSpec with Matchers with BeforeA
     assert(response.getResponseCode == ResponseCode.OK)
     val result = response.getResult
     assert(result != null)
+    
+    result.get("batchId") should be("0130929928739635201")
+    result.get("collectionId") should be("do_31309287232935526411138")
+    result.get("lastUpdatedOn") should not be(null)
     val metricsResult = gson.fromJson(gson.toJson(result.get("metrics")), classOf[util.ArrayList[util.Map[String, AnyRef]]])
     val groupByResult = gson.fromJson(gson.toJson(result.get("groupBy")), classOf[util.ArrayList[util.Map[String, AnyRef]]])
     metricsResult.isEmpty should be(false)


### PR DESCRIPTION
1. Added `batchId`, `collectionId` and `lastUpdatedOn` fields to the response object
2. Remove the gson parser and using the framework parser

**Response structure**

```js 
{
    "id": "api.collection.summary",
    "ver": "v1",
    "ts": "2020-10-20 13:36:38:427+0000",
    "params": {
        "resmsgid": null,
        "msgid": "6d87c078-2855-48b7-aa0c-09ee9dd8d0b9",
        "err": null,
        "status": "success",
        "errmsg": null
    },
    "responseCode": "OK",
    "result": {
        "lastUpdatedOn": 1603198670911,
        "metrics": [
            {
                "type": "enrolment",
                "count": 1
            }
        ],
        "groupBy": [
            {
                "district": "Tumkur",
                "values": [
                    {
                        "count": 1,
                        "type": "enrolment"
                    }
                ],
                "state": "Karnataka"
            }
        ],
        "batchId": "0130934495109529602",
        "collectionId": "do_1130934466492252161819"
    }
}```
