### PR TITLE
SB-24496 : Course batch create, update issue fix

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/CourseBatchDaoImpl.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/coursebatch/dao/impl/CourseBatchDaoImpl.java
@@ -1,21 +1,12 @@
 package org.sunbird.learner.actors.coursebatch.dao.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.text.SimpleDateFormat;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
-
 import org.sunbird.cassandra.CassandraOperation;
 import org.sunbird.common.CassandraUtil;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.models.response.Response;
 import org.sunbird.common.models.util.CassandraPropertyReader;
 import org.sunbird.common.models.util.JsonKey;
-import org.sunbird.common.models.util.ProjectUtil;
 import org.sunbird.common.request.RequestContext;
 import org.sunbird.common.responsecode.ResponseCode;
 import org.sunbird.helper.ServiceFactory;
@@ -25,25 +16,22 @@ import org.sunbird.learner.util.CourseBatchUtil;
 import org.sunbird.learner.util.Util;
 import org.sunbird.models.course.batch.CourseBatch;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class CourseBatchDaoImpl implements CourseBatchDao {
   private CassandraOperation cassandraOperation = ServiceFactory.getInstance();
   private Util.DbInfo courseBatchDb = Util.dbInfoMap.get(JsonKey.COURSE_BATCH_DB);
   private static final CassandraPropertyReader propertiesCache =
           CassandraPropertyReader.getInstance();
   private ObjectMapper mapper = new ObjectMapper();
-  private SimpleDateFormat dateFormatTimezone = ProjectUtil.getDateFormatter();
-  private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+  private String dateFormat = "yyyy-MM-dd";
 
-  public CourseBatchDaoImpl() {
-    dateFormat.setTimeZone(
-            TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
-    dateFormatTimezone.setTimeZone(
-            TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
-  }
 
   @Override
   public Response create(RequestContext requestContext, CourseBatch courseBatch) {
-    Map<String, Object> map = CourseBatchUtil.cassandraCourseMapping(courseBatch, dateFormatTimezone, dateFormat);
+    Map<String, Object> map = CourseBatchUtil.cassandraCourseMapping(courseBatch, dateFormat);
     map = CassandraUtil.changeCassandraColumnMapping(map);
     return cassandraOperation.insertRecord(
             requestContext, courseBatchDb.getKeySpace(), courseBatchDb.getTableName(), map);

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/CourseBatchUtil.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/CourseBatchUtil.java
@@ -178,11 +178,15 @@ public class CourseBatchUtil {
   }
 
   // Method will change the date variables into text with valid format
-  public static Map<String, Object> esCourseMapping(CourseBatch courseBatch, SimpleDateFormat dateFormatTimezone, SimpleDateFormat dateFormat) throws Exception {
+  public static Map<String, Object> esCourseMapping(CourseBatch courseBatch, String pattern) throws Exception {
+    SimpleDateFormat dateFormat = ProjectUtil.getDateFormatter(pattern);
+    SimpleDateFormat dateTimeFormat = ProjectUtil.getDateFormatter();
+    dateFormat.setTimeZone(TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
+    dateTimeFormat.setTimeZone(TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
     Map<String, Object> esCourseMap = mapper.convertValue(courseBatch, Map.class);
     changeInDateFormat.forEach(key -> {
       if (esCourseMap.containsKey(key))
-        esCourseMap.put(key, dateFormatTimezone.format(esCourseMap.get(key)));
+        esCourseMap.put(key, dateTimeFormat.format(esCourseMap.get(key)));
     });
     changeInSimpleDateFormat.forEach(key -> {
       if (esCourseMap.containsKey(key))
@@ -192,12 +196,16 @@ public class CourseBatchUtil {
   }
 
   // Method will change the timestamp (Long) into date with valid format
-  public static Map<String, Object> cassandraCourseMapping(CourseBatch courseBatch, SimpleDateFormat dateFormatTimezone, SimpleDateFormat dateFormat) {
+  public static Map<String, Object> cassandraCourseMapping(CourseBatch courseBatch, String pattern) {
+    SimpleDateFormat dateFormat = ProjectUtil.getDateFormatter(pattern);
+    SimpleDateFormat dateTimeFormat = ProjectUtil.getDateFormatter();
+    dateFormat.setTimeZone(TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
+    dateTimeFormat.setTimeZone(TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
     Map<String, Object> courseBatchMap = mapper.convertValue(courseBatch, Map.class);
     changeInDateFormatAll.forEach(key -> {
       try {
         if (courseBatchMap.containsKey(key))
-          courseBatchMap.put(key, setEndOfDay(key, dateFormatTimezone.parse(dateFormatTimezone.format(courseBatchMap.get(key))), dateFormat));
+          courseBatchMap.put(key, setEndOfDay(key, dateTimeFormat.parse(dateTimeFormat.format(courseBatchMap.get(key))), dateFormat));
       } catch (ParseException e) {
         logger.error(null, "CourseBatchUtil:cassandraCourseMapping: Exception occurred with message = " + e.getMessage(), e);
       }

--- a/course-mw/course-actors-common/src/test/java/org/sunbird/learner/util/CourseBatchUtilTest.java
+++ b/course-mw/course-actors-common/src/test/java/org/sunbird/learner/util/CourseBatchUtilTest.java
@@ -41,16 +41,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class CourseBatchUtilTest {
 
   private static MockerBuilder.MockersGroup group;
-  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
-  private static final SimpleDateFormat DATE_TIMEZONE_FORMAT = ProjectUtil.getDateFormatter();
+  private static final String dateformat = "yyyy-MM-dd";
 
   @Before
   public void setup() {
     group = MockerBuilder.getFreshMockerGroup().andStaticMock(Unirest.class);
-    DATE_FORMAT.setTimeZone(
-            TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
-    DATE_TIMEZONE_FORMAT.setTimeZone(
-            TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
   }
 
   @Test
@@ -191,14 +186,14 @@ public class CourseBatchUtilTest {
 
   @Test
   public void esCourseMappingTest() throws Exception {
-    Map<String, Object> esMap = CourseBatchUtil.esCourseMapping(getCourseBatch(), DATE_TIMEZONE_FORMAT, DATE_FORMAT);
+    Map<String, Object> esMap = CourseBatchUtil.esCourseMapping(getCourseBatch(), dateformat);
     Assert.assertNotNull(esMap);
     Assert.assertEquals(esMap.get(JsonKey.START_DATE), "2021-05-04");
   }
 
   @Test
   public void cassandraCourseMappingTest() throws Exception {
-    Map<String, Object> cassandraMap = CourseBatchUtil.cassandraCourseMapping(getCourseBatch(), DATE_TIMEZONE_FORMAT, DATE_FORMAT);
+    Map<String, Object> cassandraMap = CourseBatchUtil.cassandraCourseMapping(getCourseBatch(), dateformat);
     Assert.assertNotNull(cassandraMap);
     Assert.assertEquals(cassandraMap.get(JsonKey.START_DATE), new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSSZ").parse("2021-05-04 14:36:39:706+0530"));
   }

--- a/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursemanagement/CourseBatchManagementActorTest.java
+++ b/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursemanagement/CourseBatchManagementActorTest.java
@@ -512,8 +512,8 @@ public class CourseBatchManagementActorTest {
   }
 
   private void courseBatchUtilDateMethods() throws Exception {
-    doCallRealMethod().when(CourseBatchUtil.class, "cassandraCourseMapping", Mockito.any(), Mockito.any(), Mockito.any());
+    doCallRealMethod().when(CourseBatchUtil.class, "cassandraCourseMapping",Mockito.any(), Mockito.anyString());
     doCallRealMethod().when(CourseBatchUtil.class, "setEndOfDay", Mockito.any(), Mockito.any(), Mockito.any());
-    doCallRealMethod().when(CourseBatchUtil.class, "esCourseMapping", Mockito.any(), Mockito.any(), Mockito.any());
+    doCallRealMethod().when(CourseBatchUtil.class, "esCourseMapping", Mockito.any(), Mockito.anyString());
   }
 }

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/ProjectUtil.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/ProjectUtil.java
@@ -502,11 +502,14 @@ public class ProjectUtil {
   }
 
   public static SimpleDateFormat getDateFormatter() {
-    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSSZ");
+    return getDateFormatter("yyyy-MM-dd HH:mm:ss:SSSZ");
+  }
+
+  public static SimpleDateFormat getDateFormatter(String pattern) {
+    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
     simpleDateFormat.setLenient(false);
     return simpleDateFormat;
   }
-
   /** @author Manzarul */
   public enum EnrolmentType {
     open("open"),

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -268,6 +268,23 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M5</version>
+				<configuration>
+					<useSystemClassLoader>false</useSystemClassLoader>
+					<forkCount>0</forkCount>
+					<argLine>
+						--illegal-access=warn
+					</argLine>
+					<argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+					<includes>
+						<include>**/*Spec.java</include>
+						<include>**/*Test.java</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.5</version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24496" title="SB-24496" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-24496</a>  Course Batch : Batch start, end & enrolment end date goes one day before when the user updates the batch end & enrolment end date
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Fixed course batch create and update issue.
Localising SimpleDateFormatter.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] CourseBatch create with today as startDate
- [x] CourseBatch create with future date as startDate
- [x] CourseBatch update with future date as startDate, endDate and enrollmentEndDate

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

