### PR TITLE
SB-25462 fix: Added null values for date value in batch

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/CourseBatchUtil.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/util/CourseBatchUtil.java
@@ -186,12 +186,16 @@ public class CourseBatchUtil {
     dateTimeFormat.setTimeZone(TimeZone.getTimeZone(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_TIMEZONE)));
     Map<String, Object> esCourseMap = mapper.convertValue(courseBatch, Map.class);
     changeInDateFormat.forEach(key -> {
-      if (esCourseMap.containsKey(key))
+      if (null != esCourseMap.get(key))
         esCourseMap.put(key, dateTimeFormat.format(esCourseMap.get(key)));
+      else 
+        esCourseMap.put(key, null);
     });
     changeInSimpleDateFormat.forEach(key -> {
-      if (esCourseMap.containsKey(key))
+      if (null != esCourseMap.get(key))
         esCourseMap.put(key, dateFormat.format(esCourseMap.get(key)));
+      else 
+        esCourseMap.put(key, null);
     });
     esCourseMap.put(CourseJsonKey.CERTIFICATE_TEMPLATES_COLUMN, courseBatch.getCertTemplates());
     return esCourseMap;

--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ContentConsumptionActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ContentConsumptionActor.scala
@@ -22,14 +22,13 @@ import org.sunbird.learner.util.Util
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 
 class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
     private val mapper = new ObjectMapper
     private var cassandraOperation = ServiceFactory.getInstance
     private var pushTokafkaEnabled: Boolean = true //TODO: to be removed once all are in scala
     private val consumptionDBInfo = Util.dbInfoMap.get(JsonKey.LEARNER_CONTENT_DB)
-    private val groupDBInfo = Util.dbInfoMap.get(JsonKey.GROUP_ACTIVITY_DB)
+    private val assessmentAggregatorDBInfo = Util.dbInfoMap.get(JsonKey.ASSESSMENT_AGGREGATOR_DB)
     private val enrolmentDBInfo = Util.dbInfoMap.get(JsonKey.LEARNER_COURSE_DB)
     val dateFormatter = ProjectUtil.getDateFormatter
 
@@ -315,7 +314,6 @@ class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
         val contentIds = request.getRequest.getOrDefault(JsonKey.CONTENT_IDS, new java.util.ArrayList[String]()).asInstanceOf[java.util.List[String]]
         val fields = request.getRequest.getOrDefault(JsonKey.FIELDS, new java.util.ArrayList[String](){{ add(JsonKey.PROGRESS) }}).asInstanceOf[java.util.List[String]]
         val contentsConsumed = getContentsConsumption(userId, courseId, contentIds, batchId, request.getRequestContext)
-        val scores = if (fields.contains(JsonKey.ASSESSMENT_SCORE)) getScoreAgg(request.getRequestContext, userId, courseId, batchId) else mutable.Map[String, AnyRef]()
         val response = new Response
         if(CollectionUtils.isNotEmpty(contentsConsumed)) {
             val filteredContents = contentsConsumed.map(m => {
@@ -323,7 +321,7 @@ class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
                 m.put(JsonKey.COLLECTION_ID, m.getOrDefault(JsonKey.COURSE_ID, ""))
                 val formattedMap = JsonUtil.convertWithDateFormat(m, classOf[util.Map[String, Object]], dateFormatter)
                 if (fields.contains(JsonKey.ASSESSMENT_SCORE))
-                    formattedMap.putAll(mapAsJavaMap(Map(JsonKey.ASSESSMENT_SCORE -> mapAsJavaMap(Map("totalScore" -> scores.getOrElse(("score:" +m.get("contentId").asInstanceOf[String]),0d), "totalMaxScore" -> scores.getOrElse(("max_score:" +m.get("contentId").asInstanceOf[String]),0d))))))
+                    formattedMap.putAll(mapAsJavaMap(Map(JsonKey.ASSESSMENT_SCORE -> getScore(userId, courseId, m.get("contentId").asInstanceOf[String], batchId, request.getRequestContext))))
                 formattedMap
             }).asJava
             response.put(JsonKey.RESPONSE, filteredContents)
@@ -339,12 +337,26 @@ class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
         cassandraOperation = cassandraOps
         this
     }
-    
-    def getScoreAgg(requestContext: RequestContext, userId: String, courseId: String, batchId: String) = {
-        val primaryKeys = Map[String, AnyRef]("activity_type" -> "Course", "activity_id" -> courseId, "user_id" -> userId, "context_id" -> ("cb:" + batchId)).asJava
-        val response = cassandraOperation.getRecordByIdentifier(requestContext, groupDBInfo.getKeySpace, groupDBInfo.getTableName, primaryKeys, List[String]("agg").asJava)
-        val result = response.getResult.getOrDefault(JsonKey.RESPONSE, new java.util.ArrayList[java.util.Map[String, AnyRef]]).asInstanceOf[java.util.List[java.util.Map[String, AnyRef]]]
-        result.asScala.head.asScala.getOrElse("agg", new java.util.HashMap[String, AnyRef]()).asInstanceOf[java.util.Map[String, AnyRef]].asScala
+
+    def getScore(userId: String, courseId: String, contentId: String, batchId: String, requestContext: RequestContext): util.List[util.Map[String, AnyRef]] = {
+        val filters = new java.util.HashMap[String, AnyRef]() {
+            {
+                put("user_id", userId)
+                put("course_id", courseId)
+                put("batch_id", batchId)
+                put("content_id", contentId)
+            }
+        }
+        val fieldsToGet = new java.util.ArrayList[String](){{
+            add("attempt_id")
+            add("last_attempted_on")
+            add("total_max_score")
+            add("total_score")
+        }}
+        val limit = if (StringUtils.isNotBlank(ProjectUtil.getConfigValue("assessment.attempts.limit")))
+            (ProjectUtil.getConfigValue("assessment.attempts.limit")).asInstanceOf[Integer] else 25.asInstanceOf[Integer]
+        val response = cassandraOperation.getRecordsWithLimit(requestContext, assessmentAggregatorDBInfo.getKeySpace, assessmentAggregatorDBInfo.getTableName, filters, fieldsToGet, limit)
+        response.getResult.getOrDefault(JsonKey.RESPONSE, new java.util.ArrayList[java.util.Map[String, AnyRef]]).asInstanceOf[java.util.List[java.util.Map[String, AnyRef]]]
     }
 
     def processEnrolmentSync(request: Request, requestedBy: String, requestedFor: String): Unit = {

--- a/course-mw/enrolment-actor/src/test/scala/org/sunbird/enrolments/CourseConsumptionActorTest.scala
+++ b/course-mw/enrolment-actor/src/test/scala/org/sunbird/enrolments/CourseConsumptionActorTest.scala
@@ -7,17 +7,17 @@ import akka.testkit.TestKit
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 import org.sunbird.cassandra.CassandraOperation
+import org.sunbird.common.Constants
 import org.sunbird.common.exception.ProjectCommonException
 import org.sunbird.common.inf.ElasticSearchService
 import org.sunbird.common.models.response.Response
+import org.sunbird.common.models.util.{JsonKey, ProjectUtil}
 import org.sunbird.common.request.{Request, RequestContext}
 import org.sunbird.common.responsecode.ResponseCode
 import org.sunbird.dto.SearchDTO
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-import scala.collection.JavaConverters._
-import scala.collection.JavaConversions._
 
 class CourseConsumptionActorTest extends FlatSpec with Matchers with MockFactory {
     implicit val ec: ExecutionContext = ExecutionContext.global
@@ -223,6 +223,14 @@ class CourseConsumptionActorTest extends FlatSpec with Matchers with MockFactory
                 put("courseId", "do_123")
                 put("batchId", "0123")
                 put("contentId", "do_456")
+                put("score", new java.util.ArrayList[java.util.Map[String, Object]](){{
+                    add(new java.util.HashMap[String, AnyRef](){{
+                        put("totalMaxScore", 1.asInstanceOf[AnyRef])
+                        put("lastAttemptedOn", "2019-05-13 16:08:45:125+0530")
+                        put("totalScore", 1.asInstanceOf[AnyRef])
+                        put("attemptId", "do_123")
+                    }})
+                }})
             }})
             add(new java.util.HashMap[String, AnyRef] {{
                 put("userId", "user1")
@@ -231,17 +239,8 @@ class CourseConsumptionActorTest extends FlatSpec with Matchers with MockFactory
                 put("contentId", "do_789")
             }})
         }})
-        val score = new Response()
-        score.put("response", new java.util.ArrayList[java.util.Map[String, AnyRef]] {{
-            add(new java.util.HashMap[String, AnyRef] {{
-                put("agg", new java.util.HashMap[String, AnyRef] {{
-                    put("max_score:do_789", 10.asInstanceOf[AnyRef])
-                    put("score:do_789", 1.asInstanceOf[AnyRef])
-                }})
-            }})
-        }})
         (cassandraOperation.getRecords(_:RequestContext, _: String, _: String, _: java.util.Map[String, AnyRef], _: java.util.List[String])).expects(*,*,*,*,*).returns(response)
-        (cassandraOperation.getRecordByIdentifier(_: RequestContext, _: String, _: String, _: java.util.Map[String, AnyRef], _: java.util.List[String])).expects(*, *, *, *, *).returns(score).anyNumberOfTimes()
+        (cassandraOperation.getRecordsWithLimit(_: RequestContext, _: String, _: String, _: java.util.Map[String, AnyRef], _: java.util.List[String], _: Int)).expects(*, *, *, *, *, *).returns(response).anyNumberOfTimes()
         val result = callActor(getStateReadRequestWithFields(), Props(new ContentConsumptionActor().setCassandraOperation(cassandraOperation, false)))
         println("result : " + result)
         assert(null!= result)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25462" title="SB-25462" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-25462</a>  "Join Course" button is disabled in the course batch pop up in which user has enrolled into the Expired batch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

