### PR TITLE
SB-26091: Fix assessment event with proper profile userid

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ContentConsumptionActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/ContentConsumptionActor.scala
@@ -87,9 +87,9 @@ class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
         val primaryUserId = if(StringUtils.isNotBlank(requestedFor)) requestedFor else requestedBy
         val updatedData: java.util.List[java.util.Map[String, AnyRef]] = data.map(assess => {
             assess.put(JsonKey.USER_ID, primaryUserId)
-            val assessEvents = assess.getOrDefault(JsonKey.ASSESSMENT_EVENT_ID, new java.util.ArrayList[java.util.Map[String, AnyRef]])
+            val assessEvents = assess.getOrDefault(JsonKey.ASSESSMENT_EVENTS_KEY, new java.util.ArrayList[java.util.Map[String, AnyRef]])
               .asInstanceOf[java.util.List[java.util.Map[String, AnyRef]]]
-            val assessData :java.util.List[java.util.Map[String, AnyRef]]= assessEvents.map(event=> {
+            val assessEventData :java.util.List[java.util.Map[String, AnyRef]]= assessEvents.map(event=> {
                 val actorEvent = event.getOrDefault(JsonKey.ASSESSMENT_ACTOR,
                     new java.util.HashMap[String,AnyRef]).asInstanceOf[java.util.Map[String,AnyRef]]
                 if(!actorEvent.isEmpty) {
@@ -98,7 +98,7 @@ class ContentConsumptionActor @Inject() extends BaseEnrolmentActor {
                 }
                 event
             }).toList
-            assess.put("events",assessData)
+            assess.put("events",assessEventData)
             assess
         })
         updatedData.toList.groupBy(d => d.get(JsonKey.USER_ID).asInstanceOf[String])

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -79,6 +79,8 @@ public final class JsonKey {
   public static final String ASSESSMENT_STATUS = "assessmentStatus";
   public static final String ASSESSMENT_TYPE = "assessmentType";
   public static final String ATTEMPT_ID = "attemptId";
+  public static final String ASSESSMENT_EVENT_ID = "events";
+  public static final String ASSESSMENT_ACTOR = "actor";
   public static final String ATTEMPTED_COUNT = "attemptedCount";
   public static final String AUTH_TOKEN = "authToken";
   public static final String AUTH_USER_HEADER = "X-Authenticated-Userid";

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -79,7 +79,7 @@ public final class JsonKey {
   public static final String ASSESSMENT_STATUS = "assessmentStatus";
   public static final String ASSESSMENT_TYPE = "assessmentType";
   public static final String ATTEMPT_ID = "attemptId";
-  public static final String ASSESSMENT_EVENT_ID = "events";
+  public static final String ASSESSMENT_EVENTS_KEY = "events";
   public static final String ASSESSMENT_ACTOR = "actor";
   public static final String ATTEMPTED_COUNT = "attemptedCount";
   public static final String AUTH_TOKEN = "authToken";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26091" title="SB-26091" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-26091</a>  Assessment  progress not getting updated when  the users  switch between the main account and managed user account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This include fix for replacing the user id in assessment events with corresponding user profile id

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

