### PR TITLE
SB-27410 feat: Enhanced group API for best-score

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/group/GroupAggregatesActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/group/GroupAggregatesActor.scala
@@ -103,7 +103,9 @@ class GroupAggregatesActor @Inject()(implicit val cacheUtil: RedisCacheUtil) ext
       val membersMap = groupMembers.asScala.toList.filter(x => StringUtils.isNotBlank(x.getOrDefault("userId", "").asInstanceOf[String]))
         .map(obj => (obj.getOrDefault("userId", "").asInstanceOf[String], obj)).toMap.asJava
       usersAggs.map(dbAggRecord => {
-        val dbAgg = dbAggRecord.get("agg").asInstanceOf[java.util.Map[String, AnyRef]]
+        val aggregates: Map[String, Double] = dbAggRecord.get("aggregates").asInstanceOf[java.util.Map[String, AnyRef]].asScala.map(e => e._1 -> e._2.asInstanceOf[java.lang.Double].toDouble).toMap
+        val aggs: Map[String, Double] = dbAggRecord.get("agg").asInstanceOf[java.util.Map[String, AnyRef]].asScala.map(e => e._1 -> e._2.asInstanceOf[java.lang.Integer].toDouble).toMap
+        val dbAgg: Map[String, Double] = aggs ++ aggregates
         val aggLastUpdated = dbAggRecord.get("agg_last_updated").asInstanceOf[java.util.Map[String, AnyRef]]
         val agg = dbAgg.map(aggregate => Map("metric"-> aggregate._1, "value" -> aggregate._2, "lastUpdatedOn" -> aggLastUpdated.get(aggregate._1)).asJava).toList.asJava
         val userId = dbAggRecord.get("user_id").asInstanceOf[String]

--- a/course-mw/enrolment-actor/src/test/scala/org/sunbird/group/GroupAggregatesActorTest.scala
+++ b/course-mw/enrolment-actor/src/test/scala/org/sunbird/group/GroupAggregatesActorTest.scala
@@ -101,6 +101,9 @@ class GroupAggregatesActorTest extends FlatSpec with Matchers with MockFactory {
         put("agg", new util.HashMap[String, AnyRef](){{
           put("completedCount", 1.asInstanceOf[AnyRef])
         }})
+        put("aggregates", new util.HashMap[String, AnyRef](){{
+          put("completedCount", 1.toDouble.asInstanceOf[AnyRef])
+        }})
         put("agg_last_updated", new util.HashMap[String, AnyRef](){{
           put("completedCount", new java.util.Date())
         }})


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27410" title="SB-27410" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-27410</a>  Assessment Archival: Compute best score and max-score aggregates
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

