### PR TITLE
SB-26473 feat: Additional Props on cert QR scan

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/certificate/service/CourseBatchCertificateActor.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/actors/certificate/service/CourseBatchCertificateActor.java
@@ -122,16 +122,15 @@ public class CourseBatchCertificateActor extends BaseActor {
                 CourseJsonKey.NOTIFY_TEMPLATE,
                 mapper.writeValueAsString(template.get(CourseJsonKey.NOTIFY_TEMPLATE)));
       }
+      if (MapUtils.isNotEmpty((Map<String,Object>)template.get(CourseJsonKey.ADDITIONAL_PROPS))) {
+        template.put(
+            CourseJsonKey.ADDITIONAL_PROPS,
+            mapper.writeValueAsString(template.get(CourseJsonKey.ADDITIONAL_PROPS)));
+      }
     } catch (JsonProcessingException ex) {
       ProjectCommonException.throwClientErrorException(
           ResponseCode.invalidData,
-          "Error in parsing template data, Please check "
-              + JsonKey.CRITERIA
-              + ","
-              + CourseJsonKey.ISSUER
-              + " and "
-              + CourseJsonKey.SIGNATORY_LIST
-              + " fields");
+          "Error in parsing certificate template data, Please check fields data and dataTypes");
     }
   }
 
@@ -182,6 +181,14 @@ public class CourseBatchCertificateActor extends BaseActor {
                         (String) template.get(CourseJsonKey.NOTIFY_TEMPLATE),
                         new TypeReference<HashMap<String, Object>>() {
                         }));
+      }
+      if(StringUtils.isNotEmpty((String)template.get(CourseJsonKey.ADDITIONAL_PROPS))) {
+        template.put(
+            CourseJsonKey.ADDITIONAL_PROPS,
+            mapper.readValue(
+                (String) template.get(CourseJsonKey.ADDITIONAL_PROPS),
+                new TypeReference<HashMap<String, Object>>() {
+                }));
       }
     } catch (Exception ex) {
       logger.error(null, "CourseBatchCertificateActor:mapToObject Exception occurred with error message ==", ex);

--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/constants/CourseJsonKey.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/constants/CourseJsonKey.java
@@ -29,4 +29,5 @@ public abstract class CourseJsonKey {
       "sunbird_send_email_notifictaion_api";
   public static final String NOTIFY_TEMPLATE="notifyTemplate";
   public static final String CERT_TEMPLATES = "certTemplates";
+    public static final String ADDITIONAL_PROPS = "additionalProps";
 }

--- a/course-mw/course-actors/src/main/java/org/sunbird/learner/actors/coursebatch/CourseBatchManagementActor.java
+++ b/course-mw/course-actors/src/main/java/org/sunbird/learner/actors/coursebatch/CourseBatchManagementActor.java
@@ -591,14 +591,15 @@ public class CourseBatchManagementActor extends BaseActor {
   }
 
   private Map<String, Object> getContentDetails(RequestContext requestContext, String courseId, Map<String, String> headers) {
-    Map<String, Object> ekStepContent = ContentUtil.getContent(courseId, Arrays.asList("status", "batches"));
+    Map<String, Object> ekStepContent = ContentUtil.getContent(courseId, Arrays.asList("status", "batches", "leafNodesCount"));
     logger.info(requestContext, "CourseBatchManagementActor:getEkStepContent: courseId: " + courseId, null,
             ekStepContent);
     String status = (String) ((Map<String, Object>)ekStepContent.getOrDefault("content", new HashMap<>())).getOrDefault("status", "");
+    Integer leafNodesCount = (Integer) ((Map<String, Object>) ekStepContent.getOrDefault("content", new HashMap<>())).getOrDefault("leafNodesCount", 0);
     if (null == ekStepContent ||
             ekStepContent.size() == 0 ||
-            !validCourseStatus.contains(status)) {
-      logger.info(requestContext, "CourseBatchManagementActor:getEkStepContent: Not found course for ID = " + courseId);
+            !validCourseStatus.contains(status) || leafNodesCount == 0) {
+      logger.info(requestContext, "CourseBatchManagementActor:getEkStepContent: Invalid courseId = " + courseId);
       throw new ProjectCommonException(
           ResponseCode.invalidCourseId.getErrorCode(),
           ResponseCode.invalidCourseId.getErrorMessage(),

--- a/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursebatch/CourseBatchManagementActorTest.java
+++ b/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursebatch/CourseBatchManagementActorTest.java
@@ -143,6 +143,7 @@ public class CourseBatchManagementActorTest extends SunbirdApplicationActorTest 
       put("content", new HashMap<String, Object>() {{
         put("contentType", "Course");
         put("status", "Live");
+        put("leafNodesCount", 1);
       }});
     }};
     when(ContentUtil.getContent(

--- a/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursemanagement/CourseBatchManagementActorTest.java
+++ b/course-mw/course-actors/src/test/java/org/sunbird/learner/actors/coursemanagement/CourseBatchManagementActorTest.java
@@ -532,6 +532,36 @@ public class CourseBatchManagementActorTest {
             .equals(ResponseCode.invalidBatchStartDateError.getErrorCode()));
   }
 
+  @Test
+  public void testBatchCreationFailureOnEmptyLeafNodes() throws Exception {
+    int batchProgressStatus = ProjectUtil.ProgressStatus.NOT_STARTED.getValue();
+    Response mockGetRecordByIdResponse = getMockCassandraRecordByIdResponse(batchProgressStatus);
+    when(mockCassandraOperation.getRecordByIdentifier(
+        Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.any()))
+        .thenReturn(mockGetRecordByIdResponse);
+    mockCourseEnrollmentActorWithOutLeafNodes();
+
+    TestKit probe = new TestKit(system);
+    ActorRef subject = system.actorOf(props);
+    Request reqObj = new Request();
+    reqObj.setOperation(ActorOperations.UPDATE_BATCH.getValue());
+    HashMap<String, Object> innerMap = new HashMap<>();
+    innerMap.put(JsonKey.ID, BATCH_ID);
+    innerMap.put(JsonKey.NAME, BATCH_NAME);
+    innerMap.put(JsonKey.START_DATE, existingStartDate);
+    innerMap.put(JsonKey.END_DATE, null);
+    innerMap.put(JsonKey.ENROLLMENT_END_DATE, null);
+    reqObj.getRequest().putAll(innerMap);
+    subject.tell(reqObj, probe.getRef());
+    ProjectCommonException exception =
+        probe.expectMsgClass(duration("10 second"), ProjectCommonException.class);
+
+    Assert.assertTrue(
+        ((ProjectCommonException) exception)
+            .getCode()
+            .equals(ResponseCode.invalidCourseId.getErrorCode()));
+  }
+
   private Map<String, Object> getCertTemplate() throws Exception{
     String template = " {\n" +
             "    \"template_01_prad\": {\n" +
@@ -551,10 +581,22 @@ public class CourseBatchManagementActorTest {
       put("content", new HashMap<String, Object>() {{
         put("contentType", "Course");
         put("status", "Live");
+        put("leafNodesCount", 1);
       }});
     }};
     when(ContentUtil.getContent(
             Mockito.anyString(), Mockito.anyList())).thenReturn(courseMap);
+  }
+
+  private void mockCourseEnrollmentActorWithOutLeafNodes(){
+    Map<String, Object> courseMap = new HashMap<String, Object>() {{
+      put("content", new HashMap<String, Object>() {{
+        put("contentType", "Course");
+        put("status", "Live");
+      }});
+    }};
+    when(ContentUtil.getContent(
+        Mockito.anyString(), Mockito.anyList())).thenReturn(courseMap);
   }
 
   private void courseBatchUtilDateMethods() throws Exception {

--- a/service/app/controllers/certificate/CertificateRequestValidator.java
+++ b/service/app/controllers/certificate/CertificateRequestValidator.java
@@ -70,6 +70,14 @@ public class CertificateRequestValidator extends BaseRequestValidator {
               ResponseCode.dataTypeError.getErrorMessage(), CourseJsonKey.SIGNATORY_LIST, "List"),
           ResponseCode.CLIENT_ERROR.getResponseCode());
     }
+    if (template.containsKey(CourseJsonKey.ADDITIONAL_PROPS)
+        && !(template.get(CourseJsonKey.ADDITIONAL_PROPS) instanceof Map)) {
+      throw new ProjectCommonException(
+          ResponseCode.dataTypeError.getErrorCode(),
+          MessageFormat.format(
+              ResponseCode.dataTypeError.getErrorMessage(), CourseJsonKey.ADDITIONAL_PROPS, "Map"),
+          ResponseCode.CLIENT_ERROR.getResponseCode());
+    }
   }
 
   public void validateDeleteCertificateRequest(Request certRequestDto) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26473" title="SB-26473" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />SB-26473</a>  [User & Org] Addition information to be show after scanning of certificate QR code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

