### PR TITLE
Issue SB-28980 | Added validation on signatorylist attributes in add template api

### DIFF
--- a/course-mw/course-actors-common/src/main/java/org/sunbird/learner/constants/CourseJsonKey.java
+++ b/course-mw/course-actors-common/src/main/java/org/sunbird/learner/constants/CourseJsonKey.java
@@ -1,5 +1,8 @@
 package org.sunbird.learner.constants;
 
+import java.util.Arrays;
+import java.util.List;
+
 public abstract class CourseJsonKey {
 
   public static final String ACTOR = "actor";
@@ -22,6 +25,7 @@ public abstract class CourseJsonKey {
   public static final String TEMPLATE_ID = "templateId";
   public static final String ISSUER = "issuer";
   public static final String SIGNATORY_LIST = "signatoryList";
+  public static final List<String> SIGNATORY_LIST_ATTRIBUTES = Arrays.asList("name","id","designation","image");
   public static final String ENROLLMENT = "enrollment";
   public static final String SCORE = "score";
   public static final String ASSESMENT_CRITERIA = "ge, le, eq";

--- a/service/app/controllers/certificate/CertificateRequestValidator.java
+++ b/service/app/controllers/certificate/CertificateRequestValidator.java
@@ -3,6 +3,11 @@ package controllers.certificate;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.sunbird.common.exception.ProjectCommonException;
 import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.common.request.BaseRequestValidator;
@@ -69,6 +74,22 @@ public class CertificateRequestValidator extends BaseRequestValidator {
           MessageFormat.format(
               ResponseCode.dataTypeError.getErrorMessage(), CourseJsonKey.SIGNATORY_LIST, "List"),
           ResponseCode.CLIENT_ERROR.getResponseCode());
+    }
+    if (template.containsKey(CourseJsonKey.SIGNATORY_LIST)
+            && (template.get(CourseJsonKey.SIGNATORY_LIST) instanceof List)) {
+      List<Object> signatoryList = (List<Object>) template.get(CourseJsonKey.SIGNATORY_LIST);
+      signatoryList.forEach(signatory->{
+        Map<String, Object> data = (Map<String, Object>) signatory;
+        if(MapUtils.isNotEmpty(data)){
+          CourseJsonKey.SIGNATORY_LIST_ATTRIBUTES.forEach(attr->{
+            if (Objects.isNull(data.get(attr)) || StringUtils.isNotBlank(data.get(attr).toString())){
+              ProjectCommonException.throwClientErrorException(
+                      ResponseCode.invalidData,
+                      "Mandatory attributes for signatory list are missing");
+            }
+          });
+        }
+      });
     }
     if (template.containsKey(CourseJsonKey.ADDITIONAL_PROPS)
         && !(template.get(CourseJsonKey.ADDITIONAL_PROPS) instanceof Map)) {

--- a/service/app/controllers/certificate/CertificateRequestValidator.java
+++ b/service/app/controllers/certificate/CertificateRequestValidator.java
@@ -75,8 +75,7 @@ public class CertificateRequestValidator extends BaseRequestValidator {
               ResponseCode.dataTypeError.getErrorMessage(), CourseJsonKey.SIGNATORY_LIST, "List"),
           ResponseCode.CLIENT_ERROR.getResponseCode());
     }
-    if (template.containsKey(CourseJsonKey.SIGNATORY_LIST)
-            && (template.get(CourseJsonKey.SIGNATORY_LIST) instanceof List)) {
+    if (template.containsKey(CourseJsonKey.SIGNATORY_LIST)) {
       List<Object> signatoryList = (List<Object>) template.get(CourseJsonKey.SIGNATORY_LIST);
       signatoryList.forEach(signatory->{
         Map<String, Object> data = (Map<String, Object>) signatory;

--- a/service/app/controllers/certificate/CertificateRequestValidator.java
+++ b/service/app/controllers/certificate/CertificateRequestValidator.java
@@ -78,10 +78,10 @@ public class CertificateRequestValidator extends BaseRequestValidator {
     if (template.containsKey(CourseJsonKey.SIGNATORY_LIST)) {
       List<Object> signatoryList = (List<Object>) template.get(CourseJsonKey.SIGNATORY_LIST);
       signatoryList.forEach(signatory->{
-        Map<String, Object> data = (Map<String, Object>) signatory;
+        Map<String, String> data = (Map<String, String>) signatory;
         if(MapUtils.isNotEmpty(data)){
           CourseJsonKey.SIGNATORY_LIST_ATTRIBUTES.forEach(attr->{
-            if (Objects.isNull(data.get(attr)) || StringUtils.isNotBlank(data.get(attr).toString())){
+            if (StringUtils.isNotBlank(data.get(attr))){
               ProjectCommonException.throwClientErrorException(
                       ResponseCode.invalidData,
                       "Mandatory attributes for signatory list are missing");

--- a/service/app/controllers/certificate/CertificateRequestValidator.java
+++ b/service/app/controllers/certificate/CertificateRequestValidator.java
@@ -84,7 +84,7 @@ public class CertificateRequestValidator extends BaseRequestValidator {
             if (StringUtils.isNotBlank(data.get(attr))){
               ProjectCommonException.throwClientErrorException(
                       ResponseCode.invalidData,
-                      "Mandatory attributes for signatory list are missing");
+                      "Signatory list missing attribute: " + attr);
             }
           });
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28980" title="SB-28980" target="_blank"><img alt="Enhancement" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10311?size=medium" />SB-28980</a>  Add validation to Certificate SignatoryList attributes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java-11, play2-2.7.2, scala-2.11, redis-5.0.3
* Hardware versions: 2 CPU / 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

